### PR TITLE
[R6Pugs] Channel Category Support

### DIFF
--- a/r6pugs/errors.py
+++ b/r6pugs/errors.py
@@ -8,29 +8,35 @@ __all__ = [
 
 class R6PugsError(Exception):
     """Base class for this module."""
+
     pass
 
 
 class Forbidden(R6PugsError):
     """User is not permitted to join a PuG."""
+
     pass
 
 
 class ExtensionNotFound(R6PugsError):
     """R6Pugs extension was not found."""
+
     pass
 
 
 class InvalidExtension(R6PugsError):
     """There was an error in the extension python."""
+
     pass
 
 
 class ReactionMenuError(Exception):
     """Base class for ReactionMenus."""
+
     pass
 
 
 class MenuNotSent(ReactionMenuError):
     """No message has been sent yet."""
+
     pass

--- a/r6pugs/extensions/pugnotifications/__init__.py
+++ b/r6pugs/extensions/pugnotifications/__init__.py
@@ -1,4 +1,5 @@
-"""
+"""Notifications extension for R6Pugs.
+
 This extension allows users to stay notified of PUGs starting in
 various different ways.
 """

--- a/r6pugs/extensions/pugstats/__init__.py
+++ b/r6pugs/extensions/pugstats/__init__.py
@@ -3,5 +3,5 @@ from .pugstats import *
 
 
 def setup(bot):
-    """Load PugStats"""
+    """Load PugStats."""
     bot.add_cog(PugStats())

--- a/r6pugs/extensions/pugstats/pugstats.py
+++ b/r6pugs/extensions/pugstats/pugstats.py
@@ -7,8 +7,9 @@ __all__ = ["PugStats"]
 
 
 class PugStats:
-    """An addon for R6Pugs which keeps track of stats for
-     each player / server.
+    """Stats extension for R6Pugs.
+
+    This extension keeps track of basic stats for each player / server.
     """
 
     def __init__(self):
@@ -17,7 +18,10 @@ class PugStats:
         self.conf.register_member(wins=0, losses=0, map_stats={})
 
     async def on_pug_match_end(self, match: PugMatch):
-        """Fires when a pug match ends and submits the stats for each player."""
+        """Event for a PUG match ending.
+
+        Logs stats for each player in the database.
+        """
         losing_score = min(score for score in match.final_score)
         losing_team_idx = match.final_score.index(losing_score)
         losing_team = match.teams[losing_team_idx]
@@ -37,6 +41,6 @@ class PugStats:
         await total.set(total_n + 1)
         stats = await settings.map_stats()
         if map_ not in stats:
-            stats[map_] = (0, 0)
+            stats[map_] = [0, 0]
         stats[map_][int(not win)] += 1
         await settings.map_stats.set(stats)

--- a/r6pugs/extensions/pugvoice/__init__.py
+++ b/r6pugs/extensions/pugvoice/__init__.py
@@ -1,9 +1,10 @@
-"""This extension manages voice channels and moving players
-for R6Pugs.
+"""Voice extension for R6Pugs.
+
+This extension manages voice channels and moving players for R6Pugs.
 """
 from .pugvoice import *
 
 
 def setup(bot):
-    """Load PugVoice"""
+    """Load PugVoice."""
     bot.add_cog(PugVoice())

--- a/r6pugs/reactionmenus.py
+++ b/r6pugs/reactionmenus.py
@@ -29,7 +29,8 @@ class _ReactionMenu:
                                 timeout: float=None):
         """Wait for a reaction which meets the passed in requirements.
 
-        The menu must have been sent before calling."""
+        The menu must have been sent before calling.
+        """
         if self.message is None:
             raise MenuNotSent(
                 "The menu must be sent before waiting for a reaction.")
@@ -210,9 +211,7 @@ class SingleSelectionMenu(_OptionMenu):
 
 
 class PollMenu(_OptionMenu):
-    """A poll menu, where a group of users can vote on some
-     list of options.
-    """
+    """A poll menu, where a group of users can vote on some list of options."""
 
     def __init__(self,
                  bot: commands.Bot,
@@ -248,7 +247,7 @@ class PollMenu(_OptionMenu):
         return await self.finish()
 
     async def vote(self, reaction: discord.Reaction, voter: discord.Member):
-        """A user votes with a reaction."""
+        """Register a user's vote with a reaction."""
         if voter in self.voters:
             self.voters.remove(voter)
         vote = self.options[self.emojis.index(reaction.emoji)]
@@ -315,8 +314,7 @@ class _TurnBasedMenu(_OptionMenu):
                                "".format(selector, action, self.option_name)))
         await self.message.edit(embed=embed)
 
-    async def _get_response(self, selector: discord.Member, emojis: List[str]
-                            ) -> Tuple[str, discord.Member, str]:
+    async def _get_response(self, selector: discord.Member, emojis: List[str]):
         try:
             response = await self.wait_for_reaction(
                 users=[selector], emojis=emojis, timeout=self.timeout)
@@ -354,8 +352,11 @@ class _TurnBasedMenu(_OptionMenu):
 
 
 class TurnBasedVetoMenu(_TurnBasedMenu):
-    """A veto menu where two users take turns vetoing through a list
-     of options, until `n_picks` are remaning."""
+    """A veto menu where two users take turns vetoing.
+
+    The users vetothrough a list of options, until `n_picks` are remaning.
+    Then, the users will take turns selecting the remaining options.
+    """
 
     VETOED = '\N{No Entry}'
     PICKED = '\N{White Heavy Check Mark}'
@@ -428,8 +429,9 @@ class TurnBasedVetoMenu(_TurnBasedMenu):
 
 
 class TurnBasedSelectionMenu(_TurnBasedMenu):
-    """A selection menu where two users take turns selecting from
-     a list until the list is exhausted
+    """A selection menu where two users take turns selecting.
+
+    Users select from a list of options until the list is exhausted.
     """
 
     SELECTED = ('\N{Large Blue Diamond}', '\N{Large Orange Diamond}')


### PR DESCRIPTION
This PR brings a couple changes to the cog's front-end, and a fair few changes to the back-end.

## Front End

### Core functionality
When a PUG is started, a new channel category will be created with the name *PUG \<number\>*, \<number\> being the index of the PUG. Within this category, one text channel will be created with the name *#pug-\<number\>*, which is essentially the same channel which was created before this update.

### Voice extension
Voice channels will be created within the new category. Their names will be generic, i.e. won't refer to the PUG which it is currently in. The header channel has also been removed.

### Preview
![image](https://user-images.githubusercontent.com/7438501/31325586-56bd1752-ad0a-11e7-87c3-b6b7b2085dc3.png)

## Back End
`r6pugs.Pug` and `r6pugs.PugMatch` no longer have their initial command invocation context as an attribute. Instead, we have 2 new attributes for bot classes: `bot` and `channel`, as well as 2 new attributes for just the `r6pugs.Pug` class: `category` and `owner`.

I've also started some work on better docstrings so that this cog's API has some documentation to go off of.
