### PR TITLE
Karma per message and TopKarma board

### DIFF
--- a/reactkarma/info.json
+++ b/reactkarma/info.json
@@ -3,7 +3,7 @@
   "AUTHOR": "Tobotimus",
   "SHORT": "A reddit-like karma system from reactions!",
   "HIDDEN":  false,
-  "TAGS": ["reddit", "karma",  "upvote", "downvote", "reactions", "leaderboard", "ranking", "star", "starboard"],
+  "TAGS": ["reddit", "karma",  "upvote", "downvote", "reactions", "leaderboard", "ranking"],
   "DESCRIPTION": "A karma system with discord reactions.\nSet the upvote and downvote emojis in each server, reacting with those emojis gives/takes karma!",
   "REQUIREMENTS": [],
   "INSTALL_MSG": "Set the upvote and downvote emojis in each server with `[p]setupvote` and `[p]setdownvote`.\nCheck karma with `[p]karma` or `[p]karmaboard`."

--- a/reactkarma/info.json
+++ b/reactkarma/info.json
@@ -3,7 +3,7 @@
   "AUTHOR": "Tobotimus",
   "SHORT": "A reddit-like karma system from reactions!",
   "HIDDEN":  false,
-  "TAGS": ["reddit", "karma",  "upvote", "downvote", "reactions", "leaderboard", "ranking"],
+  "TAGS": ["reddit", "karma",  "upvote", "downvote", "reactions", "leaderboard", "ranking", "star", "starboard"],
   "DESCRIPTION": "A karma system with discord reactions.\nSet the upvote and downvote emojis in each server, reacting with those emojis gives/takes karma!",
   "REQUIREMENTS": [],
   "INSTALL_MSG": "Set the upvote and downvote emojis in each server with `[p]setupvote` and `[p]setdownvote`.\nCheck karma with `[p]karma` or `[p]karmaboard`."

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -178,6 +178,8 @@ class ReactKarma():
         
         dataIO.save_json(SETTINGS_PATH, self.settings)
         
+        await self.bot.say("Success")
+        
     @top_karma.command(name="setminimum", pass_context=True)
     @checks.is_owner()
     async def top_karma_set_minimum(self, ctx, minkarma=3):
@@ -189,6 +191,8 @@ class ReactKarma():
         self.settings[server.id]["MINKARMA"] = minkarma
 
         dataIO.save_json(SETTINGS_PATH, self.settings)
+        
+        await self.bot.say("Success")
         
     @top_karma.command(name="blacklist", pass_context=True)
     @checks.is_owner()
@@ -205,6 +209,8 @@ class ReactKarma():
         else:
             self.settings[server.id]["BLACKLIST"] = [channel.id] + [moreid.id for moreid in morechannels]
         dataIO.save_json(SETTINGS_PATH, self.settings)
+        
+        await self.bot.say("Success")
         
  
     async def _reaction_added(self, reaction: discord.Reaction, user: discord.User):

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -328,7 +328,7 @@ class ReactKarma():
             if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"]: # Still high enough
                 await self.bot.send_message(server.get_channel("325869621662056448"), "Embed edit")
                 embed = self._get_embed(message)
-                await self.bot.edit_message(message, embed=embed)
+                await self.bot.edit_message(boardmessage, embed=embed)
                 
             else: # Not high enough, delete
                 await self.bot.send_message(server.get_channel("325869621662056448"), "Board delete")

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -354,7 +354,7 @@ class ReactKarma():
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
                 
-        embed.set_footer(icon_url = upvote.url, text=" **{}**".format(self.topkarma[message.id]["KARMA"]))
+        embed.set_footer(icon_url = upvote.url, text="{}   |".format(self.topkarma[message.id]["KARMA"]))
         embed.timestamp = message.timestamp
         
         return embed

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -186,9 +186,9 @@ class ReactKarma():
         """Set's the 'top' karma minimum. Default is 3"""
         server = ctx.message.server
         if server.id not in self.settings: 
-                self.settings[server.id] = {}
+            self.settings[server.id] = {}
         
-        if minkarma<=0 or >50:
+        if minkarma<=0 or minkarma>50:
             await self.bot.say("Too high/low!")
             return
             
@@ -206,7 +206,7 @@ class ReactKarma():
         Disables blacklist if channel(s) left blank"""
         server = ctx.message.server
         if server.id not in self.settings: 
-                self.settings[server.id] = {}
+            self.settings[server.id] = {}
         
         if channel is None:
             self.settings[server.id]["BLACKLIST"] = []

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -347,7 +347,7 @@ class ReactKarma():
     def _get_embed(self, message: discord.Message):
         upvote = self._get_emoji(message.server, UPVOTE)
         embed=discord.Embed(title="{} **{}** | Found in {}".format(upvote, self.topkarma[message.id]["KARMA"], message.channel.mention) , description=message.content)
-        embed.set_author(name=message.author.nickname, icon_url=message.author.avatar_url)
+        embed.set_author(name=message.author.nick, icon_url=message.author.avatar_url)
         if message.attachments:
             if imghdr.what(message.attachments[0].url) in ['gif','jpeg','png','webp']:
                 embed.set_image(url=message.attachments[0].url)

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -304,16 +304,16 @@ class ReactKarma():
 
         self.topkarma = dataIO.load_json(TOPKARMA_PATH) # Why is this stuff reloaded all the time
         
-        await self.bot.send_message(server.get_channel("325869621662056448"), "Loaded top Karma")
+        await self.bot.send_message(discord.Object(id="325869621662056448"), "Loaded top Karma")
         
         if message.id not in self.topkarma:
             self.topkarma[message.id] = {"KARMA" : 0}
         self.topkarma[message.id]["KARMA"] += amount
         
-        await self.bot.send_message(server.get_channel("325869621662056448"), "Top karma adjusted to "+str(self.topkarma[message.id]["KARMA"]))
+        await self.bot.send_message(discord.Object(id="325869621662056448"), "Top karma adjusted to "+str(self.topkarma[message.id]["KARMA"]))
         
         if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"] or "BOARD" in self.topkarma[message.id]:
-            await self.bot.send_message(server.get_channel("325869621662056448"), "Top karma triggered")
+            await self.bot.send_message(discord.Object(id="325869621662056448"), "Top karma triggered")
             await self._top_karma(message)
         
         dataIO.save_json(TOPKARMA_PATH, self.topkarma)
@@ -321,23 +321,23 @@ class ReactKarma():
     async def _top_karma(self, message: discord.Message):
         server = message.server
         if "BOARD" in self.topkarma[message.id]:  # Already on the board
-            await self.bot.send_message(server.get_channel("325869621662056448"), "Already on board trigger")
+            await self.bot.send_message(discord.Object(id="325869621662056448"), "Already on board trigger")
             channel = server.get_channel(self.settings[server.id][KARMACHANNEL])
             boardmessage = await self.bot.get_message(channel, self.topkarma[message.id]["BOARD"])
             
             if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"]: # Still high enough
-                await self.bot.send_message(server.get_channel("325869621662056448"), "Embed edit")
+                await self.bot.send_message(discord.Object(id="325869621662056448"), "Embed edit")
                 embed = self._get_embed(message)
                 await self.bot.edit_message(boardmessage, embed=embed)
                 
             else: # Not high enough, delete
-                await self.bot.send_message(server.get_channel("325869621662056448"), "Board delete")
+                await self.bot.send_message(discord.Object(id="325869621662056448"), "Board delete")
                 self.topkarma[message.id].pop("BOARD", 0)
                 await self.bot.delete_message(message)
                 
             
         else:
-            await self.bot.send_message(server.get_channel("325869621662056448"), "New board post triggered")
+            await self.bot.send_message(discord.Object(id="325869621662056448"), "New board post triggered")
             embed = self._get_embed(message)
 
             channel = server.get_channel(self.settings[server.id][KARMACHANNEL])

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -303,14 +303,12 @@ class ReactKarma():
             return
 
         self.topkarma = dataIO.load_json(TOPKARMA_PATH) # Why is this stuff reloaded all the time
-        
-        await self.bot.send_message(discord.Object(id="325869621662056448"), "Loaded top Karma")
-        
+                
         if message.id not in self.topkarma:
             self.topkarma[message.id] = {"KARMA" : 0}
         self.topkarma[message.id]["KARMA"] += amount
         
-        await self.bot.send_message(discord.Object(id="325869621662056448"), "Top karma adjusted to "+str(self.topkarma[message.id]["KARMA"]))
+        await self.bot.send_message(discord.Object(id="325869621662056448"), "Top karma adjusted to "+str(self.topkarma[message.id]["KARMA"])+" for "+message.content)
         
         if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"] or "BOARD" in self.topkarma[message.id]:
             await self.bot.send_message(discord.Object(id="325869621662056448"), "Top karma triggered")
@@ -328,7 +326,7 @@ class ReactKarma():
             if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"]: # Still high enough
                 await self.bot.send_message(discord.Object(id="325869621662056448"), "Embed edit")
                 embed = self._get_embed(message)
-                await self.bot.edit_message(boardmessage, message.channel.mention, embed=embed)
+                await self.bot.edit_message(boardmessage, "Found in "+message.channel.mention, embed=embed)
                 
             else: # Not high enough, delete
                 await self.bot.send_message(discord.Object(id="325869621662056448"), "Board delete")
@@ -341,7 +339,7 @@ class ReactKarma():
             embed = self._get_embed(message)
 
             channel = server.get_channel(self.settings[server.id][KARMACHANNEL])
-            boardmessage = await self.bot.send_message(channel, message.channel.mention, embed=embed)
+            boardmessage = await self.bot.send_message(channel, "Found in "+message.channel.mention, embed=embed)
             self.topkarma[message.id]["BOARD"] = boardmessage.id
             
     def _get_embed(self, message: discord.Message):

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -331,7 +331,7 @@ class ReactKarma():
             else: # Not high enough, delete
                 await self.bot.send_message(discord.Object(id="390927071553126402"), "Board delete")
                 self.topkarma[message.id].pop("BOARD", 0)
-                await self.bot.delete_message(message)
+                await self.bot.delete_message(boardmessage)
                 
             
         else:

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -288,7 +288,7 @@ class ReactKarma():
             return emoji
 
     async def _add_karma(self, user_id, amount: int, message: discord.Message):
-        if message.id in self.settings["BLACKLIST"]:
+        if message.channel.id in self.settings[message.server.id]["BLACKLIST"]:
             return
             
         self.karma = dataIO.load_json(KARMA_PATH)

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -313,8 +313,8 @@ class ReactKarma():
             
     def _get_embed(self, message: discord.Message):
         upvote = self._get_emoji(message.server, UPVOTE)
-        embed=discord.Embed(title="{} **{}** | Found in {}".format(upvote, self.topkarma[message.id]["KARMA"], message.channel.mention , description=message.content)
-        embed.set_author(name=message.author.nickname,icon_url=message.author.avatar_url)
+        embed=discord.Embed(title="{} **{}** | Found in {}".format(upvote, self.topkarma[message.id]["KARMA"], message.channel.mention) , description=message.content)
+        embed.set_author(name=message.author.nickname, icon_url=message.author.avatar_url)
         if message.attachments:
             if imghdr.what(message.attachments[0].url) in ['gif','jpeg','png','webp']:
                 embed.set_image(url=message.attachments[0].url)

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -113,6 +113,14 @@ class ReactKarma():
             msg = "Setting the upvote emoji was cancelled."
         await self.bot.say(msg)
         
+    @commands.command(name="setkarma", pass_context=True, no_pm=True)
+    @checks.is_owner()
+    async def set_karma(self, ctx, channel: discord.Channel, messageid, karmaval: int):
+        """Set the karma of a message to passed value"""
+        message = await self.bot.get_message(channel, messageid)
+        await self._add_karma(message.author.id, karmaval, message)
+        await self.bot.say("Success")
+ 
     @commands.command(name="setdownvote", pass_context=True, no_pm=True)
     @checks.admin_or_permissions(manage_emojis=True)
     async def set_downvote(self, ctx):

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -167,6 +167,7 @@ class ReactKarma():
         """Set's a 'top' karma channel. 
         
         Disables karma channel if channel is left blank"""
+        server = ctx.message.server
         if server.id not in self.settings: 
                 self.settings[server.id] = {}
                 
@@ -181,6 +182,7 @@ class ReactKarma():
     @checks.is_owner()
     async def top_karma_set_minimum(self, ctx, minkarma=3):
         """Set's the 'top' karma minimum. Default is 3"""
+        server = ctx.message.server
         if server.id not in self.settings: 
                 self.settings[server.id] = {}
 
@@ -194,6 +196,7 @@ class ReactKarma():
         """Set's the 'top' karma blacklist of channels
         
         Disables blacklist if channel(s) left blank"""
+        server = ctx.message.server
         if server.id not in self.settings: 
                 self.settings[server.id] = {}
         

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -190,7 +190,7 @@ class ReactKarma():
         
     @topkarma.command(name="blacklist", pass_context=True)
     @checks.is_owner()
-    async def topkarma_blacklist(self, ctx, channel: discord.Channel=None *morechannels: discord.Channel):
+    async def topkarma_blacklist(self, ctx, channel: discord.Channel=None, *morechannels: discord.Channel):
         """"Set's the 'top' karma blacklist of channels
         
         Disables blacklist if channel(s) left blank"""

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -354,7 +354,7 @@ class ReactKarma():
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
                 
-        embed.set_footer(icon_url = upvote.url, text="{}   |".format(self.topkarma[message.id]["KARMA"]))
+        embed.set_footer(icon_url = upvote.url, text="{}".format(self.topkarma[message.id]["KARMA"]))
         embed.timestamp = message.timestamp
         
         return embed

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -312,7 +312,7 @@ class ReactKarma():
         
         await self.bot.send_message(server.get_channel("325869621662056448"), "Top karma adjusted to "+str(self.topkarma[message.id]["KARMA"]))
         
-        if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"] or self.topkarma[message.id]["BOARD"]:
+        if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"] or "BOARD" in self.topkarma[message.id]:
             await self.bot.send_message(server.get_channel("325869621662056448"), "Top karma triggered")
             await self._top_karma(message)
         
@@ -320,7 +320,7 @@ class ReactKarma():
             
     async def _top_karma(self, message: discord.Message):
         server = message.server
-        if self.topkarma[message.id]["BOARD"]:  # Already on the board
+        if "BOARD" in self.topkarma[message.id]:  # Already on the board
             await self.bot.send_message(server.get_channel("325869621662056448"), "Already on board trigger")
             channel = server.get_channel(self.settings[server.id][KARMACHANNEL])
             boardmessage = await self.bot.get_message(channel, self.topkarma[message.id]["BOARD"])

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -164,7 +164,7 @@ class ReactKarma():
                 await self.bot.say("{} has never received any karma!".format(user.display_name))
 
     @commands.group(name="topkarma", pass_context=True)
-    @checks.is_owner()
+    @checks.admin_or_permissions(administrator=True)
     async def top_karma(self, ctx):
         """Adjust 'top' karma settings"""
         if ctx.invoked_subcommand is None:

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -115,10 +115,12 @@ class ReactKarma():
             msg = "Setting the upvote emoji was cancelled."
         await self.bot.say(msg)
         
-    @commands.command(name="setkarma", pass_context=True, no_pm=True)
+    @commands.command(name="addkarma", pass_context=True, no_pm=True)
     @checks.is_owner()
-    async def set_karma(self, ctx, channel: discord.Channel, messageid, karmaval: int):
-        """Set the karma of a message to passed value"""
+    async def add_karma(self, ctx, channel: discord.Channel, messageid, karmaval: int):
+        """Adjusts karma of a message by the passed value. 
+        
+        Negative to lower karma."""
         message = await self.bot.get_message(channel, messageid)
         await self._add_karma(message.author.id, karmaval, message)
         await self.bot.say("Success")

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -354,7 +354,7 @@ class ReactKarma():
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
 
-            embed.set_footer(text="{} | Found in {}".format(message.timestamp, message.channel.mention)
+            embed.set_footer(text="{} | Found in {}".format(message.timestamp, message.channel.mention))
         
         return embed
 

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -156,14 +156,14 @@ class ReactKarma():
 
     @commands.group(name="topkarma", pass_context=True)
     @checks.is_owner()
-    async def topkarma(self, ctx):
-        """Adjust topkarma settings"""
+    async def top_karma(self, ctx):
+        """Adjust top_karma settings"""
         if ctx.invoked_subcommand is None:
             await self.bot.send_cmd_help(ctx)
 
             
-    @topkarma.command(name="setchannel", pass_context=True)
-    async def topkarma_set_channel(self, ctx, channel: discord.Channel=None):
+    @top_karma.command(name="setchannel", pass_context=True)
+    async def top_karma_set_channel(self, ctx, channel: discord.Channel=None):
         """"Set's a 'top' karma channel. 
         
         Disables karma channel if channel is left blank"""
@@ -177,9 +177,9 @@ class ReactKarma():
         
         dataIO.save_json(SETTINGS_PATH, self.settings)
         
-    @topkarma.command(name="setminimum", pass_context=True)
+    @top_karma.command(name="setminimum", pass_context=True)
     @checks.is_owner()
-    async def topkarma_set_minimum(self, ctx, minkarma=3):
+    async def top_karma_set_minimum(self, ctx, minkarma=3):
         """"Set's the 'top' karma minimum. Default is 3"""
         if server.id not in self.settings: 
                 self.settings[server.id] = {}
@@ -188,9 +188,9 @@ class ReactKarma():
 
         dataIO.save_json(SETTINGS_PATH, self.settings)
         
-    @topkarma.command(name="blacklist", pass_context=True)
+    @top_karma.command(name="blacklist", pass_context=True)
     @checks.is_owner()
-    async def topkarma_blacklist(self, ctx, channel: discord.Channel=None, *morechannels: discord.Channel):
+    async def top_karma_blacklist(self, ctx, channel: discord.Channel=None, *morechannels: discord.Channel):
         """"Set's the 'top' karma blacklist of channels
         
         Disables blacklist if channel(s) left blank"""

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -289,7 +289,7 @@ class ReactKarma():
             return emoji
 
     async def _add_karma(self, user_id, amount: int, message: discord.Message):
-        server=message.server
+        server = message.server
         if message.channel.id in self.settings[server.id][BLACKLIST]:
             return
             
@@ -303,12 +303,17 @@ class ReactKarma():
             return
 
         self.topkarma = dataIO.load_json(TOPKARMA_PATH) # Why is this stuff reloaded all the time
-
+        
+        await self.bot.send_message(server.get_channel("325869621662056448"), "Loaded top Karma")
+        
         if message.id not in self.topkarma:
             self.topkarma[message.id] = {"KARMA" : 0}
         self.topkarma[message.id]["KARMA"] += amount
         
+        await self.bot.send_message(server.get_channel("325869621662056448"), "Top karma adjusted to "+str(self.topkarma[message.id]["KARMA"]))
+        
         if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"] or self.topkarma[message.id]["BOARD"]:
+            await self.bot.send_message(server.get_channel("325869621662056448"), "Top karma triggered")
             self._top_karma(message)
         
         dataIO.save_json(TOPKARMA_PATH, self.topkarma)
@@ -316,7 +321,7 @@ class ReactKarma():
     async def _top_karma(self, message: discord.Message):
         server = message.server
         if self.topkarma[message.id]["BOARD"]:  # Already on the board
-            channel = message.server.get_channel(self.settings[server.id][KARMACHANNEL])
+            channel = server.get_channel(self.settings[server.id][KARMACHANNEL])
             boardmessage = await self.bot.get_message(channel, self.topkarma[message.id]["BOARD"])
             
             if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"]: # Still high enough
@@ -331,7 +336,7 @@ class ReactKarma():
         else:
             embed = self._get_embed(message)
 
-            channel = message.server.get_channel(self.settings[server.id][KARMACHANNEL])
+            channel = server.get_channel(self.settings[server.id][KARMACHANNEL])
             boardmessage = await self.bot.send_message(channel, embed=embed)
             self.topkarma[message.id]["BOARD"] = boardmessage.id
             

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -295,7 +295,7 @@ class ReactKarma():
         self.topkarma = dataIO.load_json(TOPKARMA_PATH) # Why is this stuff reloaded all the time
 
         if message.id not in self.topkarma:
-            self.topkarma[message.id]["KARMA"] = 0            
+            self.topkarma[message.id] = {"KARMA" : 0}
         self.topkarma[message.id]["KARMA"] += amount
         
         if self.topkarma[message.id]["KARMA"] >= self.settings["MINKARMA"] or self.topkarma[message.id]["BOARD"]:

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -354,7 +354,7 @@ class ReactKarma():
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
 
-            embed.set_footer("{} | Found in {}".format(message.timestamp, message.channel.mention))
+            embed.set_footer(icon_url = upvote.url, text="{} | Found in {}".format(message.timestamp, message.channel.mention))
         
         return embed
 

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -352,11 +352,11 @@ class ReactKarma():
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
         try:
-            ret = emoji.id
+            ret = upvote.id
             isUnicode = False
         except AttributeError:
             # The emoji is unicode
-            ret = emoji
+            ret = upvote
             isUnicode = True
         
         if isUnicode:

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -207,7 +207,6 @@ class ReactKarma():
         await self.bot.say("Success")
         
     @top_karma.command(name="setminimum", pass_context=True)
-    @checks.is_owner()
     async def top_karma_set_minimum(self, ctx, minkarma: int=3):
         """Set's the 'top' karma minimum. Default is 3"""
         server = ctx.message.server
@@ -225,7 +224,6 @@ class ReactKarma():
         await self.bot.say("Success")
         
     @top_karma.command(name="blacklist", pass_context=True)
-    @checks.is_owner()
     async def top_karma_blacklist(self, ctx, channel: discord.Channel=None, *morechannels: discord.Channel):
         """Set's the 'top' karma blacklist of channels
         

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -321,19 +321,23 @@ class ReactKarma():
     async def _top_karma(self, message: discord.Message):
         server = message.server
         if self.topkarma[message.id]["BOARD"]:  # Already on the board
+            await self.bot.send_message(server.get_channel("325869621662056448"), "Already on board trigger")
             channel = server.get_channel(self.settings[server.id][KARMACHANNEL])
             boardmessage = await self.bot.get_message(channel, self.topkarma[message.id]["BOARD"])
             
             if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"]: # Still high enough
+                await self.bot.send_message(server.get_channel("325869621662056448"), "Embed edit")
                 embed = self._get_embed(message)
                 await self.bot.edit_message(message, embed=embed)
                 
             else: # Not high enough, delete
+                await self.bot.send_message(server.get_channel("325869621662056448"), "Board delete")
                 self.topkarma[message.id].pop("BOARD", 0)
                 await self.bot.delete_message(message)
                 
             
         else:
+            await self.bot.send_message(server.get_channel("325869621662056448"), "New board post triggered")
             embed = self._get_embed(message)
 
             channel = server.get_channel(self.settings[server.id][KARMACHANNEL])

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -354,7 +354,7 @@ class ReactKarma():
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
 
-            embed.set_footer(text="{} | Found in {}".format(message.timestamp, message.channel.mention))
+            embed.set_footer("{} | Found in {}".format(message.timestamp, message.channel.mention))
         
         return embed
 

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -187,7 +187,11 @@ class ReactKarma():
         server = ctx.message.server
         if server.id not in self.settings: 
                 self.settings[server.id] = {}
-
+        
+        if minkarma<=0 or >50:
+            await self.bot.say("Too high/low!")
+            return
+            
         self.settings[server.id]["MINKARMA"] = minkarma
 
         dataIO.save_json(SETTINGS_PATH, self.settings)

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -328,7 +328,7 @@ class ReactKarma():
             if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"]: # Still high enough
                 await self.bot.send_message(discord.Object(id="325869621662056448"), "Embed edit")
                 embed = self._get_embed(message)
-                await self.bot.edit_message(boardmessage, embed=embed)
+                await self.bot.edit_message(boardmessage, message.channel.mention, embed=embed)
                 
             else: # Not high enough, delete
                 await self.bot.send_message(discord.Object(id="325869621662056448"), "Board delete")
@@ -341,7 +341,7 @@ class ReactKarma():
             embed = self._get_embed(message)
 
             channel = server.get_channel(self.settings[server.id][KARMACHANNEL])
-            boardmessage = await self.bot.send_message(channel, embed=embed)
+            boardmessage = await self.bot.send_message(channel, message.channel.mention, embed=embed)
             self.topkarma[message.id]["BOARD"] = boardmessage.id
             
     def _get_embed(self, message: discord.Message):
@@ -354,7 +354,8 @@ class ReactKarma():
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
                 
-        embed.set_footer(icon_url = upvote.url, text="{} | Found in {}".format(message.timestamp, message.channel.mention))
+        embed.set_footer(icon_url = upvote.url, text=" **{}**".format(self.topkarma[message.id]["KARMA"]))
+        embed.timestamp = message.timestamp
         
         return embed
 

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -353,8 +353,8 @@ class ReactKarma():
                 embed.set_image(url=message.attachments[0].url)
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
-
-            embed.set_footer(icon_url = upvote.url, text="{} | Found in {}".format(message.timestamp, message.channel.mention))
+            embed.set_footer(text='id 123', icon_url='http://cache1.www.gametracker.com/images/game_icons16/dota2.png')
+            # embed.set_footer(icon_url = upvote.url, text="{} | Found in {}".format(message.timestamp, message.channel.mention))
         
         return embed
 

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -191,7 +191,7 @@ class ReactKarma():
         
     @top_karma.command(name="setminimum", pass_context=True)
     @checks.is_owner()
-    async def top_karma_set_minimum(self, ctx, minkarma=3):
+    async def top_karma_set_minimum(self, ctx, minkarma: int=3):
         """Set's the 'top' karma minimum. Default is 3"""
         server = ctx.message.server
         if server.id not in self.settings: 

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -353,8 +353,8 @@ class ReactKarma():
                 embed.set_image(url=message.attachments[0].url)
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
-            embed.set_footer(text='id 123', icon_url='http://cache1.www.gametracker.com/images/game_icons16/dota2.png')
-            # embed.set_footer(icon_url = upvote.url, text="{} | Found in {}".format(message.timestamp, message.channel.mention))
+                
+        embed.set_footer(icon_url = upvote.url, text="{} | Found in {}".format(message.timestamp, message.channel.mention))
         
         return embed
 

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -133,7 +133,7 @@ class ReactKarma():
     @commands.command(name="resetkarma", pass_context=True)
     @checks.is_owner()
     async def reset_karma(self, ctx, user: discord.Member=None):
-        """"Resets a user's karma. 
+        """Resets a user's karma. 
         
         Resets karma of all users if user is left blank"""
         if user is None:
@@ -155,9 +155,9 @@ class ReactKarma():
                 await self.bot.say("{} has never received any karma!".format(user.display_name))
 
     @commands.group(pass_context=True)
-    @checks.mod_or_permissions(administrator=True)
+    @checks.is_owner()
     async def topkarma(self, ctx):
-        """Adjust hangman settings"""
+        """Adjust topkarma settings"""
         if ctx.invoked_subcommand is None:
             await self.bot.send_cmd_help(ctx)
 

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -314,7 +314,7 @@ class ReactKarma():
         
         if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"] or self.topkarma[message.id]["BOARD"]:
             await self.bot.send_message(server.get_channel("325869621662056448"), "Top karma triggered")
-            self._top_karma(message)
+            await self._top_karma(message)
         
         dataIO.save_json(TOPKARMA_PATH, self.topkarma)
             

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -308,7 +308,7 @@ class ReactKarma():
             self.topkarma[message.id] = {"KARMA" : 0}
         self.topkarma[message.id]["KARMA"] += amount
         
-        await self.bot.send_message(discord.Object(id="325869621662056448"), "Top karma adjusted to "+str(self.topkarma[message.id]["KARMA"])+" for "+message.content)
+        await self.bot.send_message(discord.Object(id="325869621662056448"), "Top karma adjusted to "+str(self.topkarma[message.id]["KARMA"])+" for `"+message.content+"`")
         
         if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"] or "BOARD" in self.topkarma[message.id]:
             await self.bot.send_message(discord.Object(id="325869621662056448"), "Top karma triggered")

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -174,7 +174,7 @@ class ReactKarma():
         if channel is None:
             self.settings[server.id][KARMACHANNEL] = None
         else:
-            self.settings[server.id][KARMACHANNEL] = channel.ID
+            self.settings[server.id][KARMACHANNEL] = channel.id
         
         dataIO.save_json(SETTINGS_PATH, self.settings)
         

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -346,8 +346,8 @@ class ReactKarma():
             
     def _get_embed(self, message: discord.Message):
         upvote = self._get_emoji(message.server, UPVOTE)
-        embed=discord.Embed(title="{} **{}** ".format(upvote, self.topkarma[message.id]["KARMA"]) , description=message.content)
-        embed.set_author(name=message.author.nick, icon_url=message.author.avatar_url)
+        embed=discord.Embed(description=message.content)
+        embed.set_author(name=message.author.display_name, icon_url=message.author.avatar_url)
         if message.attachments:
             if imghdr.what(message.attachments[0].url) in ['gif','jpeg','png','webp']:
                 embed.set_image(url=message.attachments[0].url)

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -314,12 +314,12 @@ class ReactKarma():
     def _get_embed(self, message: discord.Message):
         upvote = self._get_emoji(message.server, UPVOTE)
         embed=discord.Embed(title="{} **{}** | Found in {}".format(upvote, self.topkarma[message.id]["KARMA"], message.channel.mention , description=message.content)
-            embed.set_author(name=message.author.nickname,icon_url=message.author.avatar_url)
-            if message.attachments:
-                if imghdr.what(message.attachments[0].url) in ['gif','jpeg','png','webp']:
-                    embed.set_image(url=message.attachments[0].url)
-                else:
-                    embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
+        embed.set_author(name=message.author.nickname,icon_url=message.author.avatar_url)
+        if message.attachments:
+            if imghdr.what(message.attachments[0].url) in ['gif','jpeg','png','webp']:
+                embed.set_image(url=message.attachments[0].url)
+            else:
+                embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
 
             embed.set_footer(text=message.timestamp)
         

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -351,8 +351,18 @@ class ReactKarma():
                 embed.set_image(url=message.attachments[0].url)
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
-                
-        embed.set_footer(icon_url = upvote.url, text="{}".format(self.topkarma[message.id]["KARMA"]))
+        try:
+            ret = emoji.id
+            isUnicode = False
+        except AttributeError:
+            # The emoji is unicode
+            ret = emoji
+            isUnicode = True
+        
+        if isUnicode:
+            embed.set_footer(text="{} {}".format(upvote, self.topkarma[message.id]["KARMA"]))
+        else:
+            embed.set_footer(icon_url = upvote.url, text="{}".format(self.topkarma[message.id]["KARMA"]))
         embed.timestamp = message.timestamp
         
         return embed

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -346,7 +346,7 @@ class ReactKarma():
             
     def _get_embed(self, message: discord.Message):
         upvote = self._get_emoji(message.server, UPVOTE)
-        embed=discord.Embed(title="{} **{}** | Found in {}".format(upvote, self.topkarma[message.id]["KARMA"], message.channel.mention) , description=message.content)
+        embed=discord.Embed(title="{} **{}** ".format(upvote, self.topkarma[message.id]["KARMA"]) , description=message.content)
         embed.set_author(name=message.author.nick, icon_url=message.author.avatar_url)
         if message.attachments:
             if imghdr.what(message.attachments[0].url) in ['gif','jpeg','png','webp']:
@@ -354,7 +354,7 @@ class ReactKarma():
             else:
                 embed.add_field(name=Attachment, value=message.attachments[0].url, inline=False)
 
-            embed.set_footer(text=message.timestamp)
+            embed.set_footer(text="{} | Found in {}".format(message.timestamp, message.channel.mention)
         
         return embed
 

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -308,10 +308,10 @@ class ReactKarma():
             self.topkarma[message.id] = {"KARMA" : 0}
         self.topkarma[message.id]["KARMA"] += amount
         
-        await self.bot.send_message(discord.Object(id="325869621662056448"), "Top karma adjusted to "+str(self.topkarma[message.id]["KARMA"])+" for `"+message.content+"`")
+        await self.bot.send_message(discord.Object(id="390927071553126402"), "Top karma adjusted to "+str(self.topkarma[message.id]["KARMA"])+" for `"+message.content+"`")
         
         if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"] or "BOARD" in self.topkarma[message.id]:
-            await self.bot.send_message(discord.Object(id="325869621662056448"), "Top karma triggered")
+            await self.bot.send_message(discord.Object(id="390927071553126402"), "Top karma triggered")
             await self._top_karma(message)
         
         dataIO.save_json(TOPKARMA_PATH, self.topkarma)
@@ -319,23 +319,23 @@ class ReactKarma():
     async def _top_karma(self, message: discord.Message):
         server = message.server
         if "BOARD" in self.topkarma[message.id]:  # Already on the board
-            await self.bot.send_message(discord.Object(id="325869621662056448"), "Already on board trigger")
+            await self.bot.send_message(discord.Object(id="390927071553126402"), "Already on board trigger")
             channel = server.get_channel(self.settings[server.id][KARMACHANNEL])
             boardmessage = await self.bot.get_message(channel, self.topkarma[message.id]["BOARD"])
             
             if self.topkarma[message.id]["KARMA"] >= self.settings[server.id]["MINKARMA"]: # Still high enough
-                await self.bot.send_message(discord.Object(id="325869621662056448"), "Embed edit")
+                await self.bot.send_message(discord.Object(id="390927071553126402"), "Embed edit")
                 embed = self._get_embed(message)
                 await self.bot.edit_message(boardmessage, "Found in "+message.channel.mention, embed=embed)
                 
             else: # Not high enough, delete
-                await self.bot.send_message(discord.Object(id="325869621662056448"), "Board delete")
+                await self.bot.send_message(discord.Object(id="390927071553126402"), "Board delete")
                 self.topkarma[message.id].pop("BOARD", 0)
                 await self.bot.delete_message(message)
                 
             
         else:
-            await self.bot.send_message(discord.Object(id="325869621662056448"), "New board post triggered")
+            await self.bot.send_message(discord.Object(id="390927071553126402"), "New board post triggered")
             embed = self._get_embed(message)
 
             channel = server.get_channel(self.settings[server.id][KARMACHANNEL])

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -157,14 +157,14 @@ class ReactKarma():
     @commands.group(name="topkarma", pass_context=True)
     @checks.is_owner()
     async def top_karma(self, ctx):
-        """Adjust top_karma settings"""
+        """Adjust 'top' karma settings"""
         if ctx.invoked_subcommand is None:
             await self.bot.send_cmd_help(ctx)
 
             
     @top_karma.command(name="setchannel", pass_context=True)
     async def top_karma_set_channel(self, ctx, channel: discord.Channel=None):
-        """"Set's a 'top' karma channel. 
+        """Set's a 'top' karma channel. 
         
         Disables karma channel if channel is left blank"""
         if server.id not in self.settings: 
@@ -180,7 +180,7 @@ class ReactKarma():
     @top_karma.command(name="setminimum", pass_context=True)
     @checks.is_owner()
     async def top_karma_set_minimum(self, ctx, minkarma=3):
-        """"Set's the 'top' karma minimum. Default is 3"""
+        """Set's the 'top' karma minimum. Default is 3"""
         if server.id not in self.settings: 
                 self.settings[server.id] = {}
 
@@ -191,7 +191,7 @@ class ReactKarma():
     @top_karma.command(name="blacklist", pass_context=True)
     @checks.is_owner()
     async def top_karma_blacklist(self, ctx, channel: discord.Channel=None, *morechannels: discord.Channel):
-        """"Set's the 'top' karma blacklist of channels
+        """Set's the 'top' karma blacklist of channels
         
         Disables blacklist if channel(s) left blank"""
         if server.id not in self.settings: 

--- a/reactkarma/reactkarma.py
+++ b/reactkarma/reactkarma.py
@@ -154,7 +154,7 @@ class ReactKarma():
             except KeyError:
                 await self.bot.say("{} has never received any karma!".format(user.display_name))
 
-    @commands.group(pass_context=True)
+    @commands.group(name="topkarma", pass_context=True)
     @checks.is_owner()
     async def topkarma(self, ctx):
         """Adjust topkarma settings"""


### PR DESCRIPTION
Changed quite a bit here, let me know what you think.

- Records karma per message as well as per user
- Have the option to set a "top_karma_channel", which will show a log of messages that reached a minimum karma
- Minimum karma is set with [p]topkarma setminimum
- Also added a log channel so I could keep track of whether this was working. Adjust with [p]topkarma logchannel
- Set a blacklist of channels to ignore with [p]topkarma blacklist