### PR TITLE
[V3 filterhelp] Add init_custom for custom groups

### DIFF
--- a/filterhelp/filterhelp.py
+++ b/filterhelp/filterhelp.py
@@ -16,6 +16,9 @@ class FilterHelp(commands.Cog):
     def __init__(self, bot: Red) -> None:
         super().__init__()
         self.conf = Config.get_conf(self, identifier=UNIQUE_ID, force_registration=True)
+        if "init_custom" in dir(self.conf):
+            self.conf.init_custom("OPTIONS", 1)
+            self.conf.init_custom("OVERRIDES", 1)
         self.conf.register_custom(
             "OPTIONS",
             show_hidden=int(EnabledState.DEFAULT),


### PR DESCRIPTION
Like in title, fix for future versions of Red (which are already in V3/develop), while keeping support for older version of Red as well.
