### PR TITLE
Update errorlogs to 3.1

### DIFF
--- a/errorlogs/errorlogs.py
+++ b/errorlogs/errorlogs.py
@@ -88,6 +88,7 @@ class ErrorLogs(getattr(commands, "Cog", object)):
             )
         )
 
+    @commands.Cog.listener()
     async def on_command_error(
         self, ctx: commands.Context, error: commands.CommandError
     ):


### PR DESCRIPTION
Due to some 3.1 changes errorlogs no longer reported errors to the channel, added a @command.Cog.listener() at line 91 to fix, tested and everything looks ok otherwise. Could probably use a quick look over in case i missed something