### PR TITLE
Make `required_cogs` key a dict in `info.json` files

### DIFF
--- a/docref/info.json
+++ b/docref/info.json
@@ -5,7 +5,7 @@
   "short": "Search for references on documentation webpages.",
   "hidden": false,
   "disabled": false,
-  "required_cogs": [],
+  "required_cogs": {},
   "requirements": ["sphinx"],
   "tags": ["docs", "dev", "coding", "sphinx", "rtd", "rtfd", "rtfm", "readthedocs"],
   "type": "COG"

--- a/errorlogs/info.json
+++ b/errorlogs/info.json
@@ -5,7 +5,7 @@
   "short": "Log error tracebacks in text channels.",
   "hidden": false,
   "disabled": false,
-  "required_cogs": [],
+  "required_cogs": {},
   "requirements": [],
   "tags": ["error", "debug", "log"],
   "type": "COG"

--- a/filterhelp/info.json
+++ b/filterhelp/info.json
@@ -5,7 +5,7 @@
   "short": "Control what commands are shown on the help menu.",
   "hidden": false,
   "disabled": true,
-  "required_cogs": [],
+  "required_cogs": {},
   "requirements": [],
   "tags": ["help", "hidehelp"],
   "type": "COG"

--- a/reactkarma/info.json
+++ b/reactkarma/info.json
@@ -5,7 +5,7 @@
   "short": "Like Reddit Karma, but with discord reactions!",
   "hidden": false,
   "disabled": false,
-  "required_cogs": [],
+  "required_cogs": {},
   "requirements": [],
   "tags": ["karma", "upvote", "downvote"],
   "type": "COG"

--- a/register/info.json
+++ b/register/info.json
@@ -6,7 +6,7 @@
   "hidden": false,
   "disabled": false,
   "required_cogs": ["admin"],
-  "requirements": [],
+  "requirements": {},
   "tags": ["selfrole", "roles"],
   "type": "COG"
 }

--- a/sticky/info.json
+++ b/sticky/info.json
@@ -5,7 +5,7 @@
   "short": "Sticky messages for your channels!",
   "hidden": false,
   "disabled": false,
-  "required_cogs": [],
+  "required_cogs": {},
   "requirements": [],
   "tags": ["moderation", "channeltools"],
   "type": "COG"

--- a/streamroles/info.json
+++ b/streamroles/info.json
@@ -5,7 +5,7 @@
   "short": "Hoist users streaming on Twitch.",
   "hidden": false,
   "disabled": false,
-  "required_cogs": [],
+  "required_cogs": {},
   "requirements": [],
   "tags": ["streamers", "hoist", "twitch"],
   "type": "COG"

--- a/strikes/info.json
+++ b/strikes/info.json
@@ -5,7 +5,7 @@
   "short": "Strike misbehaving users.",
   "hidden": false,
   "disabled": false,
-  "required_cogs": [],
+  "required_cogs": {},
   "requirements": ["tabulate[widechars]"],
   "tags": ["warnings", "strikes", "reports", "mod"],
   "type": "COG"

--- a/updatered/info.json
+++ b/updatered/info.json
@@ -5,7 +5,7 @@
   "short": "A command to update Red!",
   "hidden": false,
   "disabled": false,
-  "required_cogs": [],
+  "required_cogs": {},
   "requirements": [],
   "tags": ["update"],
   "type": "COG"

--- a/welcomecount/info.json
+++ b/welcomecount/info.json
@@ -5,7 +5,7 @@
   "short": "Customisable welcome messages.",
   "hidden": false,
   "disabled": false,
-  "required_cogs": [],
+  "required_cogs": {},
   "requirements": [],
   "tags": ["welcome", "joinmessage"],
   "type": "COG"


### PR DESCRIPTION
It's nothing very important since nothing even uses this key, but `required_cogs` key should be a dict mapping a cogname to repo URL, e.g.
```json
{
    "required_cogs": {
        "adventure": "https://github.com/aikaterna/gobcog/"
    }
}
```
See [docs](https://docs.discord.red/en/latest/guide_publish_cogs.html#keys-specific-to-the-cog-info-json-case-sensitive) for more info