### PR TITLE
[Register] Fix wrong types of keys in `info.json` file

### DIFF
--- a/register/info.json
+++ b/register/info.json
@@ -5,8 +5,10 @@
   "short": "Simplifies two SelfRole commands into one.",
   "hidden": false,
   "disabled": false,
-  "required_cogs": ["admin"],
-  "requirements": {},
+  "required_cogs": {
+    "admin": "https://github.com/Cog-Creators/Red-DiscordBot"
+  },
+  "requirements": [],
   "tags": ["selfrole", "roles"],
   "type": "COG"
 }


### PR DESCRIPTION
@Tobotimus I made a mistake in #60 - I replaced `requirements` key with a dict instead of replacing `required_cogs` key with a dict for register cog.

I am actually not sure what should be put there as repo url for admin cog since it comes in core, but I just went with passing Red's repo there, tell me if you think something different should be put there.