### PR TITLE
Remove usage of `loop` arg in the code

### DIFF
--- a/docref/__init__.py
+++ b/docref/__init__.py
@@ -26,4 +26,4 @@ from .types import NodeRef  # noqa: F401
 
 
 def setup(bot):
-    bot.add_cog(DocRef(bot.loop))
+    bot.add_cog(DocRef())

--- a/docref/docref.py
+++ b/docref/docref.py
@@ -63,7 +63,7 @@ class DocRef(commands.Cog):
     I need to be able to embed links for this cog to be useful!
     """
 
-    def __init__(self, loop: asyncio.AbstractEventLoop):
+    def __init__(self):
         super().__init__()
         self.conf: Config = Config.get_conf(
             self, identifier=UNIQUE_ID, force_registration=True
@@ -73,7 +73,7 @@ class DocRef(commands.Cog):
         self.invs_data: Dict[str, InvData] = {}
         self.invs_dir: pathlib.Path = data_manager.cog_data_path(self) / "invs"
         self.invs_dir.mkdir(parents=True, exist_ok=True)
-        self.session: aiohttp.ClientSession = aiohttp.ClientSession(loop=loop)
+        self.session: aiohttp.ClientSession = aiohttp.ClientSession()
 
     @commands.command(aliases=["ref", "rtd", "rtfm"])
     async def docref(self, ctx: commands.Context, sitename: str, *, node_ref: NodeRef):

--- a/sticky/sticky.py
+++ b/sticky/sticky.py
@@ -142,9 +142,7 @@ class Sticky(commands.Cog):
                     "This will unsticky the current sticky message from "
                     "this channel. Are you sure you want to do this?"
                 )
-                start_adding_reactions(
-                    msg, emojis=ReactionPredicate.YES_OR_NO_EMOJIS, loop=ctx.bot.loop
-                )
+                start_adding_reactions(msg, emojis=ReactionPredicate.YES_OR_NO_EMOJIS)
 
                 pred = ReactionPredicate.yes_or_no(msg)
                 try:

--- a/updatered/__init__.py
+++ b/updatered/__init__.py
@@ -29,4 +29,4 @@ def setup(bot):
         # Executables previously renamed ".old" should be cleaned up
         UpdateRed.cleanup_old_executables()
 
-    bot.add_cog(UpdateRed(bot.loop))
+    bot.add_cog(UpdateRed())

--- a/updatered/updatered.py
+++ b/updatered/updatered.py
@@ -69,9 +69,6 @@ class UpdateRed(getattr(commands, "Cog", object)):
     ]
     _SAVED_PKG_RE: ClassVar[Pattern[str]] = re.compile(r"\s+Saved\s(?P<path>.*)$")
 
-    def __init__(self, loop: asyncio.AbstractEventLoop):
-        self._loop = loop
-
     @checks.is_owner()
     @commands.command(aliases=["updatered"])
     async def update(

--- a/updatered/updatered.py
+++ b/updatered/updatered.py
@@ -217,7 +217,6 @@ class UpdateRed(getattr(commands, "Cog", object)):
                 *args,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
-                loop=self._loop,
             )
 
             stdout_data = (await process.communicate())[0]


### PR DESCRIPTION
`loop` arg has been deprecated in Python 3.8 and so python projects also deprecate or remove support for `loop` arg. Therefore, I removed whole usage of `loop` arg in the code of this repository.