### PR TITLE
[ErrorLogs] fix embeds for different server messages

### DIFF
--- a/errorlogs/errorlogs.py
+++ b/errorlogs/errorlogs.py
@@ -181,7 +181,7 @@ class ErrorLogs(commands.Cog):
             )
             if diff_guild:
                 continue
-            if channel.permissions_for(ctx.me).embed_links:
+            if channel.permissions_for(getattr(channel, "guild", channel).me).embed_links:
                 await channel.send(embed=embed)
             else:
                 await channel.send(nonembed_message)


### PR DESCRIPTION
Currently, embeds works only if error happened on same guild