### PR TITLE
[Sticky] Ignore deletion error & check for perms

### DIFF
--- a/sticky/sticky.py
+++ b/sticky/sticky.py
@@ -134,6 +134,13 @@ class Sticky(commands.Cog):
                     with contextlib.suppress(discord.NotFound):
                         await msg.delete()
                     return
+            else:
+                await ctx.send(
+                    f"I don't have the add_reactions permission here. "
+                    f"Use `{ctx.prefix}unsticky yes` to remove the sticky message."
+                )
+                return
+
             await settings.set(
                 # Preserve the header setting
                 {"header_enabled": await settings.header_enabled()}
@@ -143,7 +150,8 @@ class Sticky(commands.Cog):
                 await last.delete()
 
             if msg is not None:
-                await msg.delete()
+                with contextlib.suppress(discord.NotFound):
+                    await msg.delete()
             await ctx.tick()
         finally:
             self.locked_channels.remove(channel)


### PR DESCRIPTION
Somehow a user managed to get a traceback on the message deletion right before the end of the unsticky command but I've not been able to repro it. The line numbers won't match up as I had a copy of your cog with the MIT license still in place at the top of the file.

```
Traceback (most recent call last):
  File "/.../cat38/lib/python3.8/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/.../Red-DiscordBot/cogs/CogManager/cogs/sticky/sticky.py", line 167, in unsticky
    await msg.delete()
  File "/.../cat38/lib/python3.8/site-packages/discord/message.py", line 760, in delete
    await self._state.http.delete_message(self.channel.id, self.id)
  File "/.../cat38/lib/python3.8/site-packages/discord/http.py", line 243, in request
    raise NotFound(r, data)
discord.errors.NotFound: 404 Not Found (error code: 10008): Unknown Message

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/.../cat38/lib/python3.8/site-packages/discord/ext/commands/bot.py", line 903, in invoke
    await ctx.command.invoke(ctx)
  File "/.../cat38/lib/python3.8/site-packages/discord/ext/commands/core.py", line 855, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/.../cat38/lib/python3.8/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: NotFound: 404 Not Found (error code: 10008): Unknown Message
```

Also, if the bot doesn't have perms to add reactions on the unsticky interaction there is no message posted so I added an else condition for that situation.
