### PR TITLE
[Sticky] Ability to set cooldown per channel.

### DIFF
--- a/sticky/sticky.py
+++ b/sticky/sticky.py
@@ -28,7 +28,7 @@ class Sticky(commands.Cog):
             header_enabled=True,
             advstickied={"content": None, "embed": {}},  # This is for [p]stickyexisting
             last=None,
-            cooldown=5,
+            cooldown=3,
         )
         self.locked_channels = set()
         self._channel_cvs: Dict[discord.TextChannel, asyncio.Condition] = {}
@@ -114,9 +114,9 @@ class Sticky(commands.Cog):
     async def sticky_cooldown(self, ctx: commands.Context, seconds: int):
         """Set the cooldown time for reposting sticky messages in this channel.
         
-        The cooldown must be at least 5 seconds."""
-        if seconds < 5:
-            await ctx.send("The cooldown cannot be set lower than 5 seconds.")
+        The cooldown must be at least 3 seconds."""
+        if seconds < 3:
+            await ctx.send("The cooldown cannot be set lower than 3 seconds.")
             return
         await self.conf.channel(ctx.channel).cooldown.set(seconds)
         await ctx.tick()

--- a/sticky/sticky.py
+++ b/sticky/sticky.py
@@ -18,8 +18,6 @@ log = logging.getLogger("red.sticky")
 class Sticky(commands.Cog):
     """Sticky messages to your channels."""
 
-    REPOST_COOLDOWN = 3
-
     def __init__(self, bot):
         super().__init__()
 
@@ -30,6 +28,7 @@ class Sticky(commands.Cog):
             header_enabled=True,
             advstickied={"content": None, "embed": {}},  # This is for [p]stickyexisting
             last=None,
+            cooldown=5,
         )
         self.locked_channels = set()
         self._channel_cvs: Dict[discord.TextChannel, asyncio.Condition] = {}
@@ -107,6 +106,19 @@ class Sticky(commands.Cog):
         The header is enabled by default.
         """
         await self.conf.channel(ctx.channel).header_enabled.set(true_or_false)
+        await ctx.tick()
+
+    @checks.mod_or_permissions(manage_messages=True)
+    @commands.guild_only()
+    @sticky.command(name="cooldown", aliases=["setcooldown"])
+    async def sticky_cooldown(self, ctx: commands.Context, seconds: int):
+        """Set the cooldown time for reposting sticky messages in this channel.
+        
+        The cooldown must be at least 5 seconds."""
+        if seconds < 5:
+            await ctx.send("The cooldown cannot be set lower than 5 seconds.")
+            return
+        await self.conf.channel(ctx.channel).cooldown.set(seconds)
         await ctx.tick()
 
     @checks.mod_or_permissions(manage_messages=True)
@@ -201,7 +213,8 @@ class Sticky(commands.Cog):
                 utcnow = datetime.now(timezone.utc)
 
             time_since = utcnow - last_message.created_at
-            time_to_wait = self.REPOST_COOLDOWN - time_since.total_seconds()
+            current_cooldown = settings_dict["cooldown"]
+            time_to_wait = current_cooldown - time_since.total_seconds()
             if time_to_wait > 0:
                 await asyncio.sleep(time_to_wait)
 

--- a/sticky/sticky.py
+++ b/sticky/sticky.py
@@ -18,6 +18,8 @@ log = logging.getLogger("red.sticky")
 class Sticky(commands.Cog):
     """Sticky messages to your channels."""
 
+    DEFAULT_COOLDOWN = 3
+    
     def __init__(self, bot):
         super().__init__()
 
@@ -26,9 +28,9 @@ class Sticky(commands.Cog):
         self.conf.register_channel(
             stickied=None,  # This is for [p]sticky
             header_enabled=True,
-            advstickied={"content": None, "embed": {}},  # This is for [p]stickyexisting
+            advstickied={"content": None, "embed": {}},  # This is for [p]sticky existing
             last=None,
-            cooldown=3,
+            cooldown=self.DEFAULT_COOLDOWN,  # Use the class constant here
         )
         self.locked_channels = set()
         self._channel_cvs: Dict[discord.TextChannel, asyncio.Condition] = {}
@@ -111,13 +113,22 @@ class Sticky(commands.Cog):
     @checks.mod_or_permissions(manage_messages=True)
     @commands.guild_only()
     @sticky.command(name="cooldown", aliases=["setcooldown"])
-    async def sticky_cooldown(self, ctx: commands.Context, seconds: int):
+    async def sticky_cooldown(self, ctx: commands.Context, seconds: Optional[int] = None):
         """Set the cooldown time for reposting sticky messages in this channel.
         
+        If no value is provided, resets to the default cooldown.
         The cooldown must be at least 3 seconds."""
-        if seconds < 3:
-            await ctx.send("The cooldown cannot be set lower than 3 seconds.")
+        default_cooldown = self.DEFAULT_COOLDOWN
+        
+        if seconds is None:
+            await self.conf.channel(ctx.channel).cooldown.set(default_cooldown)
+            await ctx.send(f"Cooldown has been reset to the default (**{default_cooldown} seconds**).")
             return
+            
+        if seconds < default_cooldown:
+            await ctx.send(f"The cooldown cannot be set lower than **{default_cooldown} seconds**.")
+            return
+            
         await self.conf.channel(ctx.channel).cooldown.set(seconds)
         await ctx.tick()
 
@@ -215,8 +226,17 @@ class Sticky(commands.Cog):
             time_since = utcnow - last_message.created_at
             current_cooldown = settings_dict["cooldown"]
             time_to_wait = current_cooldown - time_since.total_seconds()
-            if time_to_wait > 0:
-                await asyncio.sleep(time_to_wait)
+
+        # Release lock before sleeping to allow unsticky commands
+        if time_to_wait > 0:
+            await asyncio.sleep(time_to_wait)
+
+        async with cv:
+            await cv.wait_for(lambda: channel not in self.locked_channels)
+            # Re-check conditions after sleep
+            settings_dict = await settings.all()
+            if settings_dict["last"] != last_message_id:
+                return  # Message changed during sleep
 
             if not (
                 settings_dict["stickied"] or any(settings_dict["advstickied"].values())


### PR DESCRIPTION
- Removed the class variable: REPOST_COOLDOWN
- Per channel configuration.
- Increased the default (minimum) cooldown from 3 to **5 seconds** (to respect the API rate limit).